### PR TITLE
Add AllegroGraph support

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -6,24 +6,19 @@ BUNDLE_APP_CONFIG="/srv/ontoportal/.bundle"
 REDIS_GOO_CACHE_HOST="redis-goo-cache"
 REDIS_HTTP_CACHE_HOST="redis-http-cache"
 REDIS_PERSISTENT_HOST="redis-persistent"
-REDIS_PORT="6379"
 REPOSITORY_FOLDER="/srv/ontoportal/data/repository"
 REPORT_PATH="/srv/ontoportal/data/reports/ontologies_report.json"
 SOLR_TERM_SEARCH_URL="http://solr-term:8983/solr/term_search_core1"
 SOLR_PROP_SEARCH_URL="http://solr-prop:8983/solr/prop_search_core1"
 MGREP_HOST="mgrep"
 MGREP_PORT="55556"
-GOO_BACKEND_NAME="4store"
-GOO_PORT="9000"
+GOO_PORT=9000
 GOO_HOST="4store"
-GOO_PATH_QUERY="/sparql/"
-GOO_PATH_DATA="/data/"
-GOO_PATH_UPDATE="/update/"
 
-#agraph config
+# AllegroGraph related settings
 AGRAPH_SUPER_USER="test"
 AGRAPH_SUPER_PASSWORD="xyzzy"
 
 OP_APIKEY=<YOUR ONTOPORTAL API KEY>
-OP_API_URL=https://data.bioontology.org
-STARTER_ONTOLOGY=STY
+OP_API_URL="https://data.bioontology.org"
+STARTER_ONTOLOGY="STY"

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+.env
+dip.override.yml

--- a/README.md
+++ b/README.md
@@ -69,3 +69,6 @@ to install gems inside the API container you would need to run `dip api bundle i
 
 to test your changes you would need to run `dip api test`
 
+# AllegroGraph 
+
+Ontoportal has support for running AllegroGraph as triple store backend.  To change default 4store triple store to AllgegroGraph you would need to rename dip.override.yml.sample to dip.override.yml    

--- a/dip.override.yml.sample
+++ b/dip.override.yml.sample
@@ -1,0 +1,29 @@
+version: '7.5'
+
+compose:
+  files:
+    - docker-compose.yml
+    - docker-compose.agraph.yml
+    # uncomment docker-compose.dev.yml for active development; it will mount local project directory in the container
+    #  - docker-compose.dev.yml
+  project_name: ontoportal
+
+interaction:
+
+  ag-create-repo:
+    description: Create AG database and set up permissions
+    service: agraph
+    command: sh -c "agraph-control --config /agraph/etc/agraph.cfg start && agtool repos create ontoportal && agtool users add anonymous && agtool users grant anonymous root:ontoportal:rw"
+    compose_run_options: [ no-deps ]
+
+provision:
+  # example on how to provision API. It requires OP_APIKEY env variable
+  - dip compose down --volumes
+
+  # create AllegroGraph repository.  Enable if working with AG
+  - dip ag-create-repo
+
+  - dip cron bundle exec rake user:create[admin,admin@nodomain.org]
+  - dip cron bundle exec 'bin/ncbo_ontology_import --admin-user admin --ontologies ${STARTER_ONTOLOGY} --from-apikey ${OP_APIKEY} --from ${OP_API_URL}'
+  - dip cron bundle exec 'bin/ncbo_ontology_pull -o ${STARTER_ONTOLOGY}'
+  - dip cron bundle exec 'bin/ncbo_ontology_process -o ${STARTER_ONTOLOGY}'

--- a/dip.yml
+++ b/dip.yml
@@ -10,7 +10,7 @@ compose:
   files:
     - docker-compose.yml
     # uncomment docker-compose.dev.yml for active development; it will mount local project directory in the container
-    # - docker-compose.dev.yml
+    #  - docker-compose.dev.yml
   project_name: ontoportal
 
 interaction:
@@ -28,7 +28,7 @@ interaction:
         service: api
         command: bundle exec rackup -o 0.0.0.0 --port 9393
         compose:
-          run_options: [service-ports]
+          run_options: [ service-ports ]
       bash:
         # Run a api container without any dependent services
         description: Start shell on the API container (or open a shell without deps)
@@ -43,12 +43,8 @@ interaction:
         compose_run_options: [ no-deps ]
       # A shortcut to run unit tests
       test:
-        description: Run unit tests with 4store backend
+        description: Run API unit tests with 4store backend
         service: api
-        command: bundle exec rake test
-      test-ag:
-        description: Run unit tests with AlegroGraph backend
-        service: api-agraph
         command: bundle exec rake test
 
   cron:
@@ -61,10 +57,16 @@ interaction:
         service: ncbo_cron
         command: bundle
 
-  'redis-cli':
+  redis-cli:
     description: Run Redis console
     service: redis-ut
     command: redis-cli -h redis-ut
+
+  ag-create-repo:
+    description: Create AG database and set up permissions
+    service: agraph
+    command: sh -c "agraph-control --config /agraph/etc/agraph.cfg start && agtool repos create ontoportal && agtool users add anonymous && agtool users grant anonymous root:ontoportal:rw"
+    compose_run_options: [ no-deps ]
 
   4store-create-kb:
     description: Create 4store KB
@@ -85,15 +87,15 @@ interaction:
     compose_run_options: [ no-deps ]
 
 provision:
-  # example on how to provision API. It requires BP_APIKEY env variable
+  # example on how to provision API. It requires OP_APIKEY env variable
   - dip compose down --volumes
   - dip 4store-create-kb
+
   # - dip solr-term-init
   # - dip solr-prop-init
-  - dip cron bundle exec rake user:create['admin','admin@nodomain.org','12345678-1234-1234-9999-aabbccddeeff']
-  - dip cron bundle exec bin/ncbo_ontology_import --from-apikey ${OP_APIKEY} -o ${STARTER_ONTOLOGY} --from ${OP_API_URL} --admin-user admin
-  - dip cron bundle exec bin/ncbo_ontology_pull -o ${STARTER_ONTOLOGY}
-  - dip cron bundle exec bin/ncbo_ontology_process -o ${STARTER_ONTOLOGY}
+  - dip cron bundle exec rake user:create[admin,admin@nodomain.org]
+  - dip cron bundle exec 'bin/ncbo_ontology_import --admin-user admin --ontologies ${STARTER_ONTOLOGY} --from-apikey ${OP_APIKEY} --from ${OP_API_URL}'
+  - dip cron bundle exec 'bin/ncbo_ontology_pull -o ${STARTER_ONTOLOGY}'
+  - dip cron bundle exec 'bin/ncbo_ontology_process -o ${STARTER_ONTOLOGY}'
   #- dip cron bundle install
   #- dip api bundle install
-  #- dip bash -c bin/setup

--- a/docker-compose.agraph.yml
+++ b/docker-compose.agraph.yml
@@ -1,0 +1,46 @@
+# name: ontoportal-agraph
+
+x-app: &api
+  stdin_open: true
+  tty: true
+  environment: &env
+    GOO_BACKEND_NAME: ag
+    GOO_PORT: 10035
+    GOO_HOST: agraph
+    GOO_PATH_QUERY: /repositories/ontoportal
+    GOO_PATH_DATA: /repositories/ontoportal/statements
+    GOO_PATH_UPDATE: /repositories/ontoportal/statements
+  depends_on: &depends_on
+    solr-term:
+      condition: service_healthy
+    solr-prop:
+      condition: service_healthy
+    redis-persistent:
+      condition: service_healthy
+    redis-goo-cache:
+      condition: service_healthy
+    redis-http-cache:
+      condition: service_healthy
+    mgrep:
+      condition: service_started
+    agraph:
+      condition: service_started
+
+services:
+  api:
+    <<: *api
+
+  ncbo_cron:
+    <<: *api
+
+  agraph:
+    image: franzinc/agraph:v7.3.1
+    platform: linux/amd64
+    environment:
+      - AGRAPH_SUPER_USER=test
+      - AGRAPH_SUPER_PASSWORD=xyzzy
+    shm_size: 1g
+    volumes:
+      - ag_data:/agraph/data
+    ports:
+      - 10035:10035

--- a/docker-compose.backend_only.yml
+++ b/docker-compose.backend_only.yml
@@ -1,4 +1,4 @@
-# docker compose file for spinning up backend services only with ports mapped to local host
+# docker compose file for spinning up backend services with ports mapped to local host
 # This is useful for running api on local system (outside of docker container) while accessing
 # dockerised backend services
 
@@ -11,6 +11,7 @@ services:
 
   4store:
     image: bde2020/4store
+    platform: linux/amd64
     #volume: fourstore:/var/lib/4store
     command: >
       bash -c "4s-backend-setup --segments 4 ontoportal_kb
@@ -22,11 +23,13 @@ services:
 
   solr:
     image: ontoportal/solr-ut:0.1
+    platform: linux/amd64
     ports:
       - 8983:8983
 
   mgrep:
     image: ontoportal/mgrep:0.0.2
+    platform: linux/amd64
     # volumes:
     #  - mgrep:/srv/mgrep/dictionary
     ports:
@@ -34,6 +37,7 @@ services:
 
   agraph:
     image: franzinc/agraph:v7.3.1
+    platform: linux/amd64
     environment:
       - AGRAPH_SUPER_USER=test
       - AGRAPH_SUPER_PASSWORD=xyzzy

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -1,25 +1,17 @@
-# docker compose for running ontoportal backend for development
+# docker compose overwrite file for running ontoportal backend for development
 #
 # it expects to have git repos for ontologies_api, ncbo_cron and ontologies_linked_data
 # to be in the same directory as ontoportal_docker which will be mounted on the container
 # giving ability to run code from those directories inside container
-#
+
 x-app: &api
   build: &build
     args:
       RUBY_VERSION: '2.7'
-  # Increase the version number in the image tag every time Dockerfile or its arguments is changed
-  #  image: ontologies_api:0.0.1  #!!!!!!!!!!! will this conflict with image names we use for unit tests?
   stdin_open: true
   tty: true
   env_file:
     .env
-  volumes:
-    # bundle volume for hosting gems installed by bundle; it helps in local development with gem udpates
-    - bundle:/srv/ontoportal/bundle
-    - history:/usr/local/hist
-
-name: ontoportal-dev
 
 services:
   api:
@@ -27,11 +19,10 @@ services:
     build:
       <<: *build
       context: ../ontologies_api
-    image: ontoportal_api:0.0.1
-    env_file:
-      .env
+    image: ontoportal_api:0.0.2
     command: "bundle exec rackup -o 0.0.0.0 --port 9393"
     volumes:
+      - history:/usr/local/hist
       # bundle volume for hosting gems installed by bundle; it helps in local development with gem udpates
       - bundle:/srv/ontoportal/bundle
       # api code
@@ -46,12 +37,9 @@ services:
     build:
       <<: *build
       context: ../ncbo_cron
-    image: ncbo_cron:0.0.1
-    command: "bundle exec bin/ncbo_cron"
-    env_file:
-     .env
+    image: ncbo_cron:0.0.2
     volumes:
+      - history:/usr/local/hist
       # bundle volume for hosting gems installed by bundle; it helps in local development with gem udpates
       - bundle:/srv/ontoportal/bundle
       - ./../ncbo_cron:/srv/ontoportal/ncbo_cron
-

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,13 +3,13 @@ name: ontoportal
 x-app: &api
   stdin_open: true
   tty: true
+  env_file:
+    .env
   depends_on: &depends_on
     solr-term:
-      #condition: service_healthy
-      condition: service_started
+      condition: service_healthy
     solr-prop:
-      condition: service_started
-      #condition: service_healthy
+      condition: service_healthy
     redis-persistent:
       condition: service_healthy
     redis-goo-cache:
@@ -18,14 +18,14 @@ x-app: &api
       condition: service_healthy
     mgrep:
       condition: service_started
-      #      condition: service_healthy # FIXME: mgrep needs valid dictionary file to start which is not generated until ontology is processed
+      # condition: service_healthy # FIXME: mgrep needs valid dictionary file to start which is not generated until ontology is processed
     4store:
       condition: service_started
 
 services:
   api:
     <<: *api
-    image: bioportal/ontologies_api:0.0.1
+    image: bioportal/ontologies_api:0.0.2
     command: "bundle exec rackup -o 0.0.0.0 --port 9393"
     env_file:
       .env
@@ -35,23 +35,17 @@ services:
       - reports:/srv/ontoportal/data/reports
     ports:
       - 9393:9393
-    depends_on:
-      <<: *depends_on
 
   ncbo_cron:
     <<: *api
-    image: bioportal/ncbo_cron:0.0.1
+    image: bioportal/ncbo_cron:0.0.2
     command: "bundle exec bin/ncbo_cron"
-    env_file:
-      .env
     volumes:
       - history:/usr/local/hist
       - repository:/srv/ontoportal/data/repository
       - reports:/srv/ontoportal/data/reports
       - mgrep:/srv/ontoportal/data/mgrep
       - logs:/srv/ontoportal/ncbo_cron/logs
-    depends_on:
-      <<: *depends_on
 
   redis-persistent:
     image: redis
@@ -83,6 +77,7 @@ services:
 
   4store:
     image: bde2020/4store
+    platform: linux/amd64
     volumes:
      - 4store_data:/var/lib/4store
     command: bash -c "4s-backend ontoportal_kb && 4s-httpd -D -s-1 -p 9000 ontoportal_kb"
@@ -115,6 +110,7 @@ services:
 
   mgrep:
     image: ontoportal/mgrep:0.0.2
+    platform: linux/amd64
     volumes:
       - mgrep:/srv/mgrep/dictionary
     healthcheck:
@@ -127,6 +123,7 @@ services:
 volumes:
   bundle:
   4store_data:
+  ag_data:
   repository:
   mgrep:
   reports:


### PR DESCRIPTION
this PR includes:
- initial arm64 support
- AllegroGraph support

dip doesn't support docker profiles yet so AllegroGraph support is implemented with docker compose overrides and dip.overrides.   switching from 4store to AG requires renaming dip.overrides.yml.sampl to dip.overrides.yml
